### PR TITLE
SVD when M < N

### DIFF
--- a/lib/semantic/transform/lsa_transform.rb
+++ b/lib/semantic/transform/lsa_transform.rb
@@ -8,11 +8,14 @@ module Semantic
           # TODO configurable rank
           columns = matrix.size2
 
-          u, v, sigma = matrix.SV_decomp_mod
+          # if M < N perform SVD on transponsed matrix
+          matrix.size1 < matrix.size2 ? (u, v, sigma = matrix.transpose.SV_decomp_mod) : (u, v, sigma = matrix.SV_decomp_mod)
+
           reduce_dimensions!(sigma, rank)
           sigma = GSL::Matrix.diagonal(sigma)
 
-          GSL::Matrix.swap(matrix, u * sigma * v.transpose)
+          # if M < N return transposed result
+          matrix.size1 < matrix.size2 ? GSL::Matrix.swap(matrix, (u * sigma * v.transpose).transpose) : GSL::Matrix.swap(matrix, u * sigma * v.transpose)
         end
 
         private

--- a/spec/semantic/transform/lsa_transform_spec.rb
+++ b/spec/semantic/transform/lsa_transform_spec.rb
@@ -3,11 +3,16 @@ require File.dirname(__FILE__) + '/../../spec_helper'
 module Semantic
   describe Transform::LSA do
 
-    let(:matrix){
+    let(:matrix) {
       matrix = GSL::Matrix[[0.0, 1.0, 0.0],
                            [1.0, 0.0, 1.0],
                            [0.0, 0.0, 1.0]]
 
+    }
+
+    let(:tiny_matrix) {
+      tiny_matrix = GSL::Matrix[[0.0, 1.0, 0.0],
+                                [1.0, 0.0, 1.0]]
     }
 
     describe "latent semantic analysis transform" do
@@ -41,7 +46,22 @@ module Semantic
         transformed_matrix[8].should be_within(0.1).of(0.7)
       end
 
+      it "should transform LSA matrix when M < N" do
+        transformed_matrix = nil
+
+        expect {
+          transformed_matrix = Transform::LSA.transform! tiny_matrix
+        }.to_not raise_error
+
+        transformed_matrix[0].should be_within(0.1).of(0)
+        transformed_matrix[1].should be_within(0.1).of(0)
+        transformed_matrix[2].should be_within(0.1).of(0)
+        transformed_matrix[3].should be_within(0.1).of(1.0)
+        transformed_matrix[4].should be_within(0.1).of(0)
+        transformed_matrix[5].should be_within(0.1).of(1.0)
+      end
+
     end
 
-   end
+  end
 end


### PR DESCRIPTION
Adjusted LSA transformation to avoid error when M<N on document_matrix and rather perform SVD on transposed matrix.

error: Ruby/GSL error code 24, svd of MxN matrix, M<N, is not implemented (file svd.c, line 286), the requested feature is not (yet) implemented
