### PR TITLE
GSL Gem 1.15 Supported

### DIFF
--- a/lib/semantic/version.rb
+++ b/lib/semantic/version.rb
@@ -2,7 +2,7 @@ module Semantic #:nodoc:
   class VERSION #:nodoc:
     MAJOR = 0
     MINOR = 2
-    TINY  = 1
+    TINY  = 2
 
     STRING = [MAJOR, MINOR, TINY].join('.')
   end

--- a/rsemantic.gemspec
+++ b/rsemantic.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |s|
   s.rdoc_options     = ["--charset=UTF-8"]
   s.require_paths    = ["lib"]
 
-  s.add_runtime_dependency(%q<gsl>, ["= 1.14.7"])
-  s.add_runtime_dependency(%q<fast-stemmer>, [">= 1.0.1"])
+  s.add_runtime_dependency(%q<gsl>)
+  s.add_runtime_dependency(%q<fast-stemmer>)
 end


### PR DESCRIPTION
1.14.7 was causing build issues on OSX (was installing gsl114 via homebrew), but I was able to get it working with the latest version of the GSL gem and the latest version of GNU GSL (brew install gsl).
