### PR TITLE
Update the parser to allow stem words

### DIFF
--- a/lib/rsemantic/parser.rb
+++ b/lib/rsemantic/parser.rb
@@ -44,7 +44,7 @@ module RSemantic
       words = string.split(" ")
 
       if @stem_words
-        words.map(&:stem)
+        words.map { |word| Stemmer::stem_word(word) }
       else
         words
       end

--- a/lib/rsemantic/vector_space/builder.rb
+++ b/lib/rsemantic/vector_space/builder.rb
@@ -9,6 +9,7 @@ module RSemantic
       def initialize(options = {})
         @parser = Parser.new(
           :filter_stop_words => options[:filter_stop_words],
+          :stem_words => options[:stem_words],
           :locale => options[:locale]
         )
         @parsed_document_cache = []


### PR DESCRIPTION
This update allows the stem_words option to be passed from the builder down to the parser. It also ensures that the Stemmer class is used directly instead of assuming the String class monkey-patch from fast-stemmer is present.